### PR TITLE
Add a wart to warn against sealed case classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,9 @@ scala> for {
      | y <- x to 3
      | } yield x * y
 res1: List[Int] = List(1, 2, 3, 4, 6, 9)
+```
+
+### SealedCaseClass
+
+Reports an error/warning when a sealed case class is seen. As per FinalCaseClass wart, case classes
+should always be `final`. And, in Scala combining `final` and `sealed` together is not allowed.

--- a/src/main/scala/wartremover/contrib/warts/SealedCaseClass.scala
+++ b/src/main/scala/wartremover/contrib/warts/SealedCaseClass.scala
@@ -1,0 +1,21 @@
+package org.wartremover
+package contrib.warts
+
+object SealedCaseClass extends WartTraverser {
+  def apply(u: WartUniverse): u.Traverser = {
+    import u.universe._
+    import u.universe.Flag._
+
+    new u.Traverser {
+      override def traverse(tree: Tree): Unit = {
+        tree match {
+          // Ignore trees marked by SuppressWarnings
+          case t if hasWartAnnotation(u)(t) =>
+          case ClassDef(mods, _, _, _) if mods.hasFlag(CASE) && mods.hasFlag(SEALED) =>
+            u.error(tree.pos, "case classes must not be sealed")
+          case t => super.traverse(tree)
+        }
+      }
+    }
+  }
+}

--- a/src/test/scala/wartremover/contrib/warts/SealedCaseClassTest.scala
+++ b/src/test/scala/wartremover/contrib/warts/SealedCaseClassTest.scala
@@ -1,0 +1,41 @@
+package org.wartremover
+package contrib.test
+
+import org.scalatest.FunSuite
+
+import org.wartremover.contrib.warts.SealedCaseClass
+import org.wartremover.test.WartTestTraverser
+
+class FinalCaseClassTest extends FunSuite {
+  test("can't declare sealed case classes") {
+    val result = WartTestTraverser(SealedCaseClass) {
+      sealed case class Foo(i: Int)
+    }
+    assertResult(List("case classes must not be sealed"), "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
+  test("can declare non-sealed case classes") {
+    val result = WartTestTraverser(SealedCaseClass) {
+      case class Foo(i: Int)
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
+  test("can declare sealed regular classes") {
+    val result = WartTestTraverser(SealedCaseClass) {
+      sealed class Foo(i: Int)
+      sealed trait Bar
+      sealed abstract class Baz
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
+  test("SealedCaseClass wart obeys SuppressWarnings") {
+    val result = WartTestTraverser(SealedCaseClass) {
+      @SuppressWarnings(Array("org.wartremover.contrib.warts.SealedCaseClass"))
+      sealed case class Foo(i: Int)
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
+}


### PR DESCRIPTION
Sealed case classes do not make sense, this pull request provides a wart to report a warning/error whenever one is found.