### PR TITLE
Added the ExposedTuples wart

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,33 @@ Additional warts for wartremover.
 
 ## Warts
 
-### NoNeedForMonad
-
 Here is a list of warts under the `org.wartremover.contrib.warts` package.
+
+### ExposedTuples
+
+Tuples are described not by their semantic meaning, but by their types alone, which requires users of your API to either create that meaning themselves using unapply or to use the ugly _1, _2, ... accessors.
+
+Public API should refrain from exposing tuples and should instead consider using custom case classes to add semantic meaning.
+
+```scala
+// Won't compile:
+// | Avoid using tuples in public interfaces, as they only supply type information.
+// | Consider using a custom case class to add semantic meaning.
+def badFoo(customerTotal: (String, Long)) = {
+  // Code
+}
+```
+```scala
+// Custom case class with added semantic meaning
+final case class CustomerAccount(customerId: String, accountTotal: Long)
+
+// Will compile
+def goodFoo(customerTotal: CustomerAccount) = {
+  // Code
+}
+```
+
+### NoNeedForMonad
 
 Sometimes an additional power of `Monad` is not needed, and
 `Applicative` is enough. This issues a warning in such cases

--- a/src/main/scala/wartremover/contrib/warts/ExposedTuples.scala
+++ b/src/main/scala/wartremover/contrib/warts/ExposedTuples.scala
@@ -1,0 +1,67 @@
+package org.wartremover.contrib.warts
+
+import org.wartremover.{ WartTraverser, WartUniverse }
+
+object ExposedTuples extends WartTraverser {
+  val message: String =
+    """Avoid using tuples in public interfaces, as they only supply type information.
+      |Consider using a custom case class to add semantic meaning.""".stripMargin
+
+  def apply(u: WartUniverse): u.Traverser = {
+    import u.universe._
+
+    def typeRefContainsTuple(typeRef: TypeRef): Boolean = {
+      val TypeRef(_, sym, args) = typeRef
+
+      if (sym.fullName.matches("scala\\.Tuple[\\d]+")) {
+        true
+      } else {
+        args.exists {
+          case nextTypeTree: TypeTree => typeTreeContainsTuple(nextTypeTree)
+          case nextTypeRef: TypeRef => typeRefContainsTuple(nextTypeRef)
+          case _ => false
+        }
+      }
+    }
+
+    def typeTreeContainsTuple(typeTree: TypeTree): Boolean = {
+      typeTree.tpe match {
+        case typeRef: TypeRef => typeRefContainsTuple(typeRef)
+        case _ => false
+      }
+    }
+
+    def valDefContainsTuple(valDef: u.universe.ValDef): Boolean = {
+      valDef.tpt match {
+        case typeTree: TypeTree => typeTreeContainsTuple(typeTree)
+        case _ => false
+      }
+    }
+
+    val publicUnscopedValues = Seq(NoFlags, Flag.MUTABLE, Flag.IMPLICIT, Flag.MUTABLE | Flag.IMPLICIT)
+
+    new u.Traverser {
+      override def traverse(tree: Tree): Unit = {
+        tree match {
+          // Ignore trees marked by SuppressWarnings
+          case t if hasWartAnnotation(u)(t) =>
+
+          // Return values
+          case DefDef(modifiers, name, _, _, returnType: TypeTree, _) if !modifiers.hasFlag(Flag.PRIVATE) && name.toString != "unapply" && typeTreeContainsTuple(returnType) =>
+            u.error(tree.pos, message)
+
+          // Parameters
+          case DefDef(modifiers, _, _, parameterLists, _, _) if !modifiers.hasFlag(Flag.PRIVATE) && parameterLists.exists(_.exists(valDefContainsTuple)) =>
+            u.error(tree.pos, message)
+
+          // Val/var declarations that are not covered by the above definitions
+          case ValDef(Modifiers(flags, _, _), _, returnType: TypeTree, _) if publicUnscopedValues.contains(flags) && typeTreeContainsTuple(returnType) =>
+            u.error(tree.pos, message)
+
+          case _ =>
+            super.traverse(tree)
+        }
+      }
+    }
+  }
+}

--- a/src/main/scala/wartremover/contrib/warts/ExposedTuples.scala
+++ b/src/main/scala/wartremover/contrib/warts/ExposedTuples.scala
@@ -2,13 +2,39 @@ package org.wartremover.contrib.warts
 
 import org.wartremover.{ WartTraverser, WartUniverse }
 
+import scala.collection.mutable
+
 object ExposedTuples extends WartTraverser {
   val message: String =
     """Avoid using tuples in public interfaces, as they only supply type information.
       |Consider using a custom case class to add semantic meaning.""".stripMargin
 
+  private final case class LineInFile(path: String, line: Int)
+
   def apply(u: WartUniverse): u.Traverser = {
     import u.universe._
+
+    val linesWithError = mutable.Set.empty[LineInFile]
+
+    def addError(pos: Position): Unit = {
+      try {
+        u.error(pos, message)
+        linesWithError.add(LineInFile(pos.source.path, pos.line))
+      } catch {
+        case _: UnsupportedOperationException =>
+        // Not supported in 2.10.x but we also don't need deduplication in that version anyway
+      }
+    }
+
+    def errorAlreadyExists(pos: Position): Boolean = {
+      try {
+        linesWithError.contains(LineInFile(pos.source.path, pos.line))
+      } catch {
+        case _: UnsupportedOperationException =>
+          // Not supported in 2.10.x but we also don't need deduplication in that version anyway
+          false
+      }
+    }
 
     def typeRefContainsTuple(typeRef: TypeRef): Boolean = {
       val TypeRef(_, sym, args) = typeRef
@@ -38,25 +64,37 @@ object ExposedTuples extends WartTraverser {
       }
     }
 
-    val publicUnscopedValues = Seq(NoFlags, Flag.MUTABLE, Flag.IMPLICIT, Flag.MUTABLE | Flag.IMPLICIT)
+    // No FlagOps.& :(
+    val publicUnscopedValues = Seq(
+      NoFlags, Flag.IMPLICIT,
+      Flag.MUTABLE, Flag.MUTABLE | Flag.IMPLICIT,
+      Flag.LAZY, Flag.LAZY | Flag.IMPLICIT,
+      Flag.PROTECTED | Flag.LAZY, Flag.PROTECTED | Flag.LAZY | Flag.IMPLICIT
+    )
 
     new u.Traverser {
+
       override def traverse(tree: Tree): Unit = {
         tree match {
           // Ignore trees marked by SuppressWarnings
           case t if hasWartAnnotation(u)(t) =>
 
+          // Do not print out multiple errors for the same line, since internal implementation of vals and vars may
+          // cause this
+          case _ if errorAlreadyExists(tree.pos) =>
+            super.traverse(tree)
+
           // Return values
           case DefDef(modifiers, name, _, _, returnType: TypeTree, _) if !modifiers.hasFlag(Flag.PRIVATE) && name.toString != "unapply" && typeTreeContainsTuple(returnType) =>
-            u.error(tree.pos, message)
+            addError(tree.pos)
 
           // Parameters
           case DefDef(modifiers, _, _, parameterLists, _, _) if !modifiers.hasFlag(Flag.PRIVATE) && parameterLists.exists(_.exists(valDefContainsTuple)) =>
-            u.error(tree.pos, message)
+            addError(tree.pos)
 
           // Val/var declarations that are not covered by the above definitions
           case ValDef(modifiers, _, returnType: TypeTree, _) if publicUnscopedValues.contains(modifiers.flags) && typeTreeContainsTuple(returnType) =>
-            u.error(tree.pos, message)
+            addError(tree.pos)
 
           case _ =>
             super.traverse(tree)

--- a/src/main/scala/wartremover/contrib/warts/ExposedTuples.scala
+++ b/src/main/scala/wartremover/contrib/warts/ExposedTuples.scala
@@ -55,7 +55,7 @@ object ExposedTuples extends WartTraverser {
             u.error(tree.pos, message)
 
           // Val/var declarations that are not covered by the above definitions
-          case ValDef(Modifiers(flags, _, _), _, returnType: TypeTree, _) if publicUnscopedValues.contains(flags) && typeTreeContainsTuple(returnType) =>
+          case ValDef(modifiers, _, returnType: TypeTree, _) if publicUnscopedValues.contains(modifiers.flags) && typeTreeContainsTuple(returnType) =>
             u.error(tree.pos, message)
 
           case _ =>

--- a/src/test/scala/wartremover/contrib/warts/ExposedTuplesTest.scala
+++ b/src/test/scala/wartremover/contrib/warts/ExposedTuplesTest.scala
@@ -190,7 +190,7 @@ class ExposedTuplesTest extends FunSuite with ResultAssertions {
         var bar23: (Int, String) = ???
       }
     }
-    assertErrors(result)(ExposedTuples.message, 2)
+    assertError(result)(ExposedTuples.message)
   }
 
   test("can't expose a tuple from a protected variable in a class") {
@@ -199,7 +199,7 @@ class ExposedTuplesTest extends FunSuite with ResultAssertions {
         protected var bar24: (Int, String) = ???
       }
     }
-    assertErrors(result)(ExposedTuples.message, 2)
+    assertError(result)(ExposedTuples.message)
   }
 
   test("can expose a tuple from a private variable in a class") {
@@ -217,7 +217,7 @@ class ExposedTuplesTest extends FunSuite with ResultAssertions {
         private[warts] var bar26: (Int, String) = ???
       }
     }
-    assertErrors(result)(ExposedTuples.message, 2)
+    assertError(result)(ExposedTuples.message)
   }
 
   test("can't expose a tuple from a variable inside another type") {
@@ -418,7 +418,7 @@ class ExposedTuplesTest extends FunSuite with ResultAssertions {
         implicit var bar51: (Int, String) = ???
       }
     }
-    assertErrors(result)(ExposedTuples.message, 2)
+    assertError(result)(ExposedTuples.message)
   }
 
   test("can't expose a tuple from a protected implicit variable in a class") {
@@ -427,7 +427,7 @@ class ExposedTuplesTest extends FunSuite with ResultAssertions {
         protected implicit var bar52: (Int, String) = ???
       }
     }
-    assertErrors(result)(ExposedTuples.message, 2)
+    assertError(result)(ExposedTuples.message)
   }
 
   test("can expose a tuple from a private implicit variable in a class") {
@@ -445,7 +445,7 @@ class ExposedTuplesTest extends FunSuite with ResultAssertions {
         private[warts] implicit var bar54: (Int, String) = ???
       }
     }
-    assertErrors(result)(ExposedTuples.message, 2)
+    assertError(result)(ExposedTuples.message)
   }
 
   test("can't expose a tuple from an implicit variable inside another type") {

--- a/src/test/scala/wartremover/contrib/warts/ExposedTuplesTest.scala
+++ b/src/test/scala/wartremover/contrib/warts/ExposedTuplesTest.scala
@@ -1,0 +1,636 @@
+package org.wartremover.contrib.warts
+
+import org.scalatest.FunSuite
+import org.wartremover.contrib.test.ResultAssertions
+import org.wartremover.test.WartTestTraverser
+
+class ExposedTuplesTest extends FunSuite with ResultAssertions {
+
+  test("can't expose a tuple from a public method") {
+    val result = WartTestTraverser(ExposedTuples) {
+      def bar1(): (Int, String) = ???
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can't expose a tuple from a public method in a class") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        def bar2(): (Int, String) = ???
+      }
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can't expose a tuple from a protected method in a class") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        protected def bar3(): (Int, String) = ???
+      }
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can expose a tuple from a private method in a class") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        private def bar4(): (Int, String) = ???
+      }
+    }
+    assertEmpty(result)
+  }
+
+  test("can't expose a tuple from a private method for a scope") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        private[warts] def bar5(): (Int, String) = ???
+      }
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can't expose a tuple from a method inside another type") {
+    val result = WartTestTraverser(ExposedTuples) {
+      def bar6(): Seq[(Int, String)] = ???
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can expose a tuple from a method if it's the base type of another type") {
+    val result = WartTestTraverser(ExposedTuples) {
+      def bar7(): Map[Int, String] = ???
+    }
+    assertEmpty(result)
+  }
+
+  test("can't expose a tuple from a public method as a parameter") {
+    val result = WartTestTraverser(ExposedTuples) {
+      def bar8(baz: (Int, String)) = ???
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can't expose a tuple from a public method as a parameter in a class") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        def bar9(baz: (Int, String)) = ???
+      }
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can't expose a tuple from a protected method as a parameter in a class") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        protected def bar10(baz: (Int, String)) = ???
+      }
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can expose a tuple from a private method as a parameter in a class") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        private def bar11(baz: (Int, String)) = ???
+      }
+    }
+    assertEmpty(result)
+  }
+
+  test("can't expose a tuple from a private method as a parameter for a scope") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        private[warts] def bar12(baz: (Int, String)) = ???
+      }
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can't expose a tuple from a method as a parameter inside another type") {
+    val result = WartTestTraverser(ExposedTuples) {
+      def bar13(baz: Seq[(Int, String)]) = ???
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can expose a tuple from a method as a parameter if it's the base type of another type") {
+    val result = WartTestTraverser(ExposedTuples) {
+      def bar14(baz: Map[Int, String]) = ???
+    }
+    assertEmpty(result)
+  }
+
+  test("can't expose a tuple from a public value") {
+    val result = WartTestTraverser(ExposedTuples) {
+      val bar15: (Int, String) = ???
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can't expose a tuple from a public value in a class") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        val bar16: (Int, String) = ???
+      }
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can't expose a tuple from a protected value in a class") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        protected val bar17: (Int, String) = ???
+      }
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can expose a tuple from a private value in a class") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        private val bar18: (Int, String) = ???
+      }
+    }
+    assertEmpty(result)
+  }
+
+  test("can't expose a tuple from a private value for a scope") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        private[warts] val bar19: (Int, String) = ???
+      }
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can't expose a tuple from a value inside another type") {
+    val result = WartTestTraverser(ExposedTuples) {
+      val bar20: Seq[(Int, String)] = ???
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can expose a tuple from a value if it's the base type of another type") {
+    val result = WartTestTraverser(ExposedTuples) {
+      val bar21: Map[Int, String] = ???
+    }
+    assertEmpty(result)
+  }
+
+  test("can't expose a tuple from a public variable") {
+    val result = WartTestTraverser(ExposedTuples) {
+      var bar22: (Int, String) = ???
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can't expose a tuple from a public variable in a class") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        var bar23: (Int, String) = ???
+      }
+    }
+    assertErrors(result)(ExposedTuples.message, 2)
+  }
+
+  test("can't expose a tuple from a protected variable in a class") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        protected var bar24: (Int, String) = ???
+      }
+    }
+    assertErrors(result)(ExposedTuples.message, 2)
+  }
+
+  test("can expose a tuple from a private variable in a class") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        private var bar25: (Int, String) = ???
+      }
+    }
+    assertEmpty(result)
+  }
+
+  test("can't expose a tuple from a private variable for a scope") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        private[warts] var bar26: (Int, String) = ???
+      }
+    }
+    assertErrors(result)(ExposedTuples.message, 2)
+  }
+
+  test("can't expose a tuple from a variable inside another type") {
+    val result = WartTestTraverser(ExposedTuples) {
+      var bar27: Seq[(Int, String)] = ???
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can expose a tuple from a variable if it's the base type of another type") {
+    val result = WartTestTraverser(ExposedTuples) {
+      var bar28: Map[Int, String] = ???
+    }
+    assertEmpty(result)
+  }
+
+  test("can't expose a tuple from a public lazy value") {
+    val result = WartTestTraverser(ExposedTuples) {
+      lazy val bar29: (Int, String) = ???
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can't expose a tuple from a public lazy value in a class") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        lazy val bar30: (Int, String) = ???
+      }
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can't expose a tuple from a protected lazy value in a class") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        protected lazy val bar31: (Int, String) = ???
+      }
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can expose a tuple from a private lazy value in a class") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        private lazy val bar32: (Int, String) = ???
+      }
+    }
+    assertEmpty(result)
+  }
+
+  test("can't expose a tuple from a private lazy value for a scope") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        private[warts] lazy val bar33: (Int, String) = ???
+      }
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can't expose a tuple from a lazy value inside another type") {
+    val result = WartTestTraverser(ExposedTuples) {
+      lazy val bar34: Seq[(Int, String)] = ???
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can expose a tuple from a lazy value if it's the base type of another type") {
+    val result = WartTestTraverser(ExposedTuples) {
+      lazy val bar35: Map[Int, String] = ???
+    }
+    assertEmpty(result)
+  }
+
+  test("can't expose a tuple from a public implicit method") {
+    val result = WartTestTraverser(ExposedTuples) {
+      implicit def bar36(): (Int, String) = ???
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can't expose a tuple from a public implicit method in a class") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        implicit def bar37(): (Int, String) = ???
+      }
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can't expose a tuple from a protected implicit method in a class") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        protected implicit def bar38(): (Int, String) = ???
+      }
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can expose a tuple from a private implicit method in a class") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        private implicit def bar39(): (Int, String) = ???
+      }
+    }
+    assertEmpty(result)
+  }
+
+  test("can't expose a tuple from a private implicit method for a scope") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        private[warts] implicit def bar40(): (Int, String) = ???
+      }
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can't expose a tuple from an implicit method inside another type") {
+    val result = WartTestTraverser(ExposedTuples) {
+      implicit def bar41(): Seq[(Int, String)] = ???
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can expose a tuple from an implicit method if it's the base type of another type") {
+    val result = WartTestTraverser(ExposedTuples) {
+      implicit def bar42(): Map[Int, String] = ???
+    }
+    assertEmpty(result)
+  }
+
+  test("can't expose a tuple from a public implicit value") {
+    val result = WartTestTraverser(ExposedTuples) {
+      implicit val bar43: (Int, String) = ???
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can't expose a tuple from a public implicit value in a class") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        implicit val bar44: (Int, String) = ???
+      }
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can't expose a tuple from a protected implicit value in a class") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        protected implicit val bar45: (Int, String) = ???
+      }
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can expose a tuple from a private implicit value in a class") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        private implicit val bar46: (Int, String) = ???
+      }
+    }
+    assertEmpty(result)
+  }
+
+  test("can't expose a tuple from a private implicit value for a scope") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        private[warts] implicit val bar47: (Int, String) = ???
+      }
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can't expose a tuple from an implicit value inside another type") {
+    val result = WartTestTraverser(ExposedTuples) {
+      implicit val bar48: Seq[(Int, String)] = ???
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can expose a tuple from an implicit value if it's the base type of another type") {
+    val result = WartTestTraverser(ExposedTuples) {
+      implicit val bar49: Map[Int, String] = ???
+    }
+    assertEmpty(result)
+  }
+
+  test("can't expose a tuple from a public implicit variable") {
+    val result = WartTestTraverser(ExposedTuples) {
+      implicit var bar50: (Int, String) = ???
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can't expose a tuple from a public implicit variable in a class") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        implicit var bar51: (Int, String) = ???
+      }
+    }
+    assertErrors(result)(ExposedTuples.message, 2)
+  }
+
+  test("can't expose a tuple from a protected implicit variable in a class") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        protected implicit var bar52: (Int, String) = ???
+      }
+    }
+    assertErrors(result)(ExposedTuples.message, 2)
+  }
+
+  test("can expose a tuple from a private implicit variable in a class") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        private implicit var bar53: (Int, String) = ???
+      }
+    }
+    assertEmpty(result)
+  }
+
+  test("can't expose a tuple from a private implicit variable for a scope") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        private[warts] implicit var bar54: (Int, String) = ???
+      }
+    }
+    assertErrors(result)(ExposedTuples.message, 2)
+  }
+
+  test("can't expose a tuple from an implicit variable inside another type") {
+    val result = WartTestTraverser(ExposedTuples) {
+      implicit var bar55: Seq[(Int, String)] = ???
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can expose a tuple from an implicit variable if it's the base type of another type") {
+    val result = WartTestTraverser(ExposedTuples) {
+      implicit var bar56: Map[Int, String] = ???
+    }
+    assertEmpty(result)
+  }
+
+  test("can't expose a tuple from a public implicit lazy value") {
+    val result = WartTestTraverser(ExposedTuples) {
+      lazy implicit val bar57: (Int, String) = ???
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can't expose a tuple from a public implicit lazy value in a class") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        lazy implicit val bar58: (Int, String) = ???
+      }
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can't expose a tuple from a protected implicit lazy value in a class") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        protected lazy implicit val bar59: (Int, String) = ???
+      }
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can expose a tuple from a private implicit lazy value in a class") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        private lazy implicit val bar60: (Int, String) = ???
+      }
+    }
+    assertEmpty(result)
+  }
+
+  test("can't expose a tuple from a private implicit lazy value for a scope") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        private[warts] lazy implicit val bar61: (Int, String) = ???
+      }
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can't expose a tuple from an implicit lazy value inside another type") {
+    val result = WartTestTraverser(ExposedTuples) {
+      lazy implicit val bar62: Seq[(Int, String)] = ???
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can expose a tuple from an implicit lazy value if it's the base type of another type") {
+    val result = WartTestTraverser(ExposedTuples) {
+      lazy implicit val bar63: Map[Int, String] = ???
+    }
+    assertEmpty(result)
+  }
+
+  test("can't expose a tuple from a public method as an implicit parameter") {
+    val result = WartTestTraverser(ExposedTuples) {
+      def bar64(implicit baz: (Int, String)) = ???
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can't expose a tuple from a public method as an implicit parameter in a class") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        def bar65(implicit baz: (Int, String)) = ???
+      }
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can't expose a tuple from a protected method as an implicit parameter in a class") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        protected def bar66(implicit baz: (Int, String)) = ???
+      }
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can expose a tuple from a private method as an implicit parameter in a class") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        private def bar67(implicit baz: (Int, String)) = ???
+      }
+    }
+    assertEmpty(result)
+  }
+
+  test("can't expose a tuple from a private method as an implicit parameter for a scope") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo {
+        private[warts] def bar68(implicit baz: (Int, String)) = ???
+      }
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can't expose a tuple from a method as an implicit parameter inside another type") {
+    val result = WartTestTraverser(ExposedTuples) {
+      def bar69(implicit baz: Seq[(Int, String)]) = ???
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can expose a tuple from a method as an implicit parameter if it's the base type of another type") {
+    val result = WartTestTraverser(ExposedTuples) {
+      def bar70(implicit baz: Map[Int, String]) = ???
+    }
+    assertEmpty(result)
+  }
+
+  test("can expose a tuple from the unapply method of a case class") {
+    val result = WartTestTraverser(ExposedTuples) {
+      case class Foo(a: Int, b: Int)
+    }
+    assertEmpty(result)
+  }
+
+  test("can expose a tuple from a custom unapply method") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo(val a: Int, val b: Int)
+
+      object Foo {
+        def unapply(foo: Foo): Option[(Int, Int)] = Some((foo.a, foo.b))
+      }
+
+      // Testing to make sure unapply is properly defined
+      val foo = new Foo(1, 2)
+      val Foo(a, b) = foo
+    }
+    assertEmpty(result)
+  }
+
+  test("can't expose a tuple from a public constructor") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo(tuple: (Int, String))
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can't expose a tuple from a protected constructor") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo protected (tuple: (Int, String))
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("can expose a tuple from a private constructor") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo private (tuple: (Int, String))
+    }
+    assertEmpty(result)
+  }
+
+  test("can expose a tuple from a private scoped constructor") {
+    val result = WartTestTraverser(ExposedTuples) {
+      class Foo private[warts] (tuple: (Int, String))
+    }
+    assertError(result)(ExposedTuples.message)
+  }
+
+  test("obeys SuppressWarnings") {
+    val result = WartTestTraverser(ExposedTuples) {
+      @SuppressWarnings(Array("org.wartremover.contrib.warts.ExposedTuples"))
+      def bar(): (Int, String) = ???
+    }
+    assertEmpty(result)
+  }
+}


### PR DESCRIPTION
Tuples are described not by their semantic meaning, but by their types alone, which requires users of your API to either create that meaning themselves using unapply or to use the ugly _1, _2, ... accessors.

Public API should refrain from exposing tuples and should instead consider using custom case classes to add semantic meaning.

```scala
// Won't compile:
// | Avoid using tuples in public interfaces, as they only supply type information.
// | Consider using a custom case class to add semantic meaning.
def badFoo(customerTotal: (String, Long)) = {
  // Code
}
```
```scala
// Custom case class with added semantic meaning
final case class CustomerAccount(customerId: String, accountTotal: Long)

// Will compile
def goodFoo(customerTotal: CustomerAccount) = {
  // Code
}
```

I've tested this feature extensively, but by all means please let me know if I missed any cases.