### PR TITLE
Add OldTime wart to forbid Joda time and old Java date/time library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,6 @@
 # wartremover-contrib
 Additional warts for wartremover.
 
-## Warts
-
-Here is a list of warts under the `org.wartremover.contrib.warts` package.
-
-### ExposedTuples
-
-Tuples are described not by their semantic meaning, but by their types alone, which requires users of your API to either create that meaning themselves using unapply or to use the ugly _1, _2, ... accessors.
-
-Public API should refrain from exposing tuples and should instead consider using custom case classes to add semantic meaning.
-
-```scala
-// Won't compile:
-// | Avoid using tuples in public interfaces, as they only supply type information.
-// | Consider using a custom case class to add semantic meaning.
-def badFoo(customerTotal: (String, Long)) = {
-  // Code
-}
-```
-```scala
-// Custom case class with added semantic meaning
-final case class CustomerAccount(customerId: String, accountTotal: Long)
-
-// Will compile
 def goodFoo(customerTotal: CustomerAccount) = {
   // Code
 }
@@ -85,3 +62,17 @@ def typeInference() = {
   }
 }
 ```
+
+### StrictTime
+
+Forbids use of deprecated time APIs in favor of the [Java 8 Time API](https://docs.oracle.com/javase/8/docs/api/java/time/package-summary.html).
+
+Disabled types:
+
+* `java.util.Date`
+* `java.util.Calendar`
+* `java.util.GregorianCalendar`
+* `java.util.TimeZone`
+* `java.text.DateFormat`
+* `java.text.SimpleDateFormat`
+* `org.joda.time._`

--- a/core/src/main/scala/wartremover/contrib/warts/OldTime.scala
+++ b/core/src/main/scala/wartremover/contrib/warts/OldTime.scala
@@ -1,0 +1,106 @@
+package org.wartremover.contrib.warts
+
+import org.wartremover._
+
+/**
+ * Forbids use of
+ *  - java.util.{ Date, Calendar, GregorianCalendar, TimeZone }
+ *  - java.text.{ DateFormat, SimpleDateFormat }
+ *  - org.joda.time._
+ */
+object OldTime extends WartTraverser {
+
+  val javaError = "The old Java time API is disabled. Use Java 8 java.time._ API instead."
+
+  val jodaError = "JodaTime is disabled. Use Java 8 java.time._ API instead."
+
+  val javaTime: Set[String] = Set(
+    "java.util.Date",
+    "java.util.Calendar",
+    "java.util.GregorianCalendar",
+    "java.util.TimeZone",
+    "java.text.DateFormat",
+    "java.text.SimpleDateFormat"
+  )
+
+  def apply(u: WartUniverse): u.Traverser = {
+    import u.universe._
+    import u.universe.Flag._
+
+    implicit class TypeOps(self: Type) { // 2.10 compat
+      def typeArgs: List[Type] = self match {
+        case PolyType(args, _) => args.map(_.typeSignature)
+        case TypeRef(_, _, args) => args
+        case ExistentialType(_, u) => u.typeArgs
+        case _ => List.empty[Type]
+      }
+    }
+
+    def isJodaTime(s: Symbol): Boolean = s.fullName.startsWith("org.joda.time")
+
+    def isJavaTime(s: Symbol): Boolean = javaTime.contains(s.fullName)
+
+    def isJavaTimeImport(tree: Tree, selectors: List[ImportSelector]): Boolean =
+      selectors.map(tree.symbol.fullName + "." + _.name).exists(javaTime.contains)
+
+    new u.Traverser {
+      override def traverse(tree: Tree): Unit = tree match {
+        // Ignore trees marked by SuppressWarnings
+        case t if hasWartAnnotation(u)(t) =>
+
+        // import org.joda.time
+        case Import(tree, _) if isJodaTime(tree.symbol) =>
+          u.error(tree.pos, jodaError)
+
+        // import java.util.Date, etc.
+        case Import(tree, selectors) if isJavaTimeImport(tree, selectors) =>
+          u.error(tree.pos, javaError)
+
+        // forbid use of any type from org.joda
+        case TypeTree() if isJodaTime(tree.symbol) =>
+          u.error(tree.pos, jodaError)
+
+        // forbid use of any type that's part of the old java time API
+        case TypeTree() if isJavaTime(tree.symbol) =>
+          u.error(tree.pos, javaError)
+
+        case tt @ TypeTree() =>
+          tt.tpe match {
+            // forbid org.joda.time types in type bounds
+            case TypeBounds(a, b) if isJodaTime(a.typeSymbol) || isJodaTime(b.typeSymbol) =>
+              u.error(tree.pos, jodaError)
+            // forbid old java time API types in type bounds
+            case TypeBounds(a, b) if isJavaTime(a.typeSymbol) || isJavaTime(b.typeSymbol) =>
+              u.error(tree.pos, javaError)
+            // forbid org.joda.time types as type arguments
+            case _ if tt.tpe.typeArgs.exists(t => isJodaTime(t.typeSymbol)) =>
+              u.error(tree.pos, jodaError)
+            // forbid old java time API types as type arguments
+            case _ if tt.tpe.typeArgs.exists(t => isJavaTime(t.typeSymbol)) =>
+              u.error(tree.pos, javaError)
+            case _ =>
+              super.traverse(tree)
+          }
+
+        // forbid use of org.joda.time members
+        case Select(qual, name) if qual.toString.startsWith("org.joda.time") =>
+          u.error(tree.pos, jodaError)
+
+        // forbid use of old java time API members
+        case Select(qual, name) if javaTime.contains(qual.toString + "." + name) =>
+          u.error(tree.pos, javaError)
+
+        // forbid org.joda.time types in type applications
+        case TypeApply(fun, args) if args.exists(t => isJodaTime(t.symbol)) =>
+          u.error(tree.pos, jodaError)
+
+        // forbid old java time API types in type applications
+        case TypeApply(fun, args) if args.exists(t => isJavaTime(t.symbol)) =>
+          u.error(tree.pos, javaError)
+
+        case _ =>
+          super.traverse(tree)
+      }
+    }
+  }
+}

--- a/core/src/test/scala/wartremover/contrib/warts/FakeJodaTimeLibrary.scala
+++ b/core/src/test/scala/wartremover/contrib/warts/FakeJodaTimeLibrary.scala
@@ -1,0 +1,19 @@
+package org.joda.time
+
+class LocalDate
+class LocalTime
+class Instant
+class DateTime
+class DateTimeZone
+class Duration
+class Period
+class Interval
+
+object LocalDate
+object LocalTime
+object Instant
+object DateTime
+object DateTimeZone
+object Duration
+object Period
+object Interval

--- a/core/src/test/scala/wartremover/contrib/warts/OldTimeTest.scala
+++ b/core/src/test/scala/wartremover/contrib/warts/OldTimeTest.scala
@@ -1,0 +1,305 @@
+package org.wartremover.contrib.warts
+
+import org.scalatest.FunSuite
+import org.wartremover.contrib.test.ResultAssertions
+import org.wartremover.test.WartTestTraverser
+
+class OldTimeTest extends FunSuite with ResultAssertions {
+
+  val javaError = "The old Java time API is disabled. Use Java 8 java.time._ API instead."
+
+  val jodaError = "JodaTime is disabled. Use Java 8 java.time._ API instead."
+
+  test("disable Joda time wildcard imports") {
+    val result = WartTestTraverser(OldTime) {
+      import org.joda.time._
+    }
+    assertError(result)(jodaError)
+  }
+  test("disable Joda time explicit imports") {
+    val result = WartTestTraverser(OldTime) {
+      import org.joda.time.LocalDate
+    }
+    assertError(result)(jodaError)
+  }
+  test("disable Joda time renamed imports") {
+    val result = WartTestTraverser(OldTime) {
+      import org.joda.time.{ Instant => Something }
+    }
+    assertError(result)(jodaError)
+  }
+  test("disable Joda time erased imports") {
+    val result = WartTestTraverser(OldTime) {
+      import org.joda.time.{ Instant => _ }
+    }
+    assertError(result)(jodaError)
+  }
+
+  test("disable java.util.Date explicit imports") {
+    val result = WartTestTraverser(OldTime) {
+      import java.util.Date
+    }
+    assertError(result)(javaError)
+  }
+  test("disable java.util.Date renamed imports") {
+    val result = WartTestTraverser(OldTime) {
+      import java.util.{ Date => Something }
+    }
+    assertError(result)(javaError)
+  }
+  test("disable java.util.Date erased imports") {
+    val result = WartTestTraverser(OldTime) {
+      import java.util.{ Date => _ }
+    }
+    assertError(result)(javaError)
+  }
+
+  test("disable java.util.Calendar explicit imports") {
+    val result = WartTestTraverser(OldTime) {
+      import java.util.Calendar
+    }
+    assertError(result)(javaError)
+  }
+  test("disable java.util.Calendar renamed imports") {
+    val result = WartTestTraverser(OldTime) {
+      import java.util.{ Calendar => Something }
+    }
+    assertError(result)(javaError)
+  }
+  test("disable java.util.Calendar erased imports") {
+    val result = WartTestTraverser(OldTime) {
+      import java.util.{ Calendar => _ }
+    }
+    assertError(result)(javaError)
+  }
+
+  test("disable java.util.GregorianCalendar explicit imports") {
+    val result = WartTestTraverser(OldTime) {
+      import java.util.GregorianCalendar
+    }
+    assertError(result)(javaError)
+  }
+  test("disable java.util.GregorianCalendar renamed imports") {
+    val result = WartTestTraverser(OldTime) {
+      import java.util.{ GregorianCalendar => Something }
+    }
+    assertError(result)(javaError)
+  }
+  test("disable java.util.GregorianCalendar erased imports") {
+    val result = WartTestTraverser(OldTime) {
+      import java.util.{ GregorianCalendar => _ }
+    }
+    assertError(result)(javaError)
+  }
+
+  test("disable java.util.TimeZone explicit imports") {
+    val result = WartTestTraverser(OldTime) {
+      import java.util.TimeZone
+    }
+    assertError(result)(javaError)
+  }
+  test("disable java.util.TimeZone renamed imports") {
+    val result = WartTestTraverser(OldTime) {
+      import java.util.{ TimeZone => Something }
+    }
+    assertError(result)(javaError)
+  }
+  test("disable java.util.TimeZone erased imports") {
+    val result = WartTestTraverser(OldTime) {
+      import java.util.{ TimeZone => _ }
+    }
+    assertError(result)(javaError)
+  }
+
+  test("disable java.text.DateFormat explicit imports") {
+    val result = WartTestTraverser(OldTime) {
+      import java.text.DateFormat
+    }
+    assertError(result)(javaError)
+  }
+  test("disable java.text.DateFormat renamed imports") {
+    val result = WartTestTraverser(OldTime) {
+      import java.text.{ DateFormat => Something }
+    }
+    assertError(result)(javaError)
+  }
+  test("disable java.text.DateFormat erased imports") {
+    val result = WartTestTraverser(OldTime) {
+      import java.text.{ DateFormat => _ }
+    }
+    assertError(result)(javaError)
+  }
+
+  test("disable java.text.SimpleDateFormat explicit imports") {
+    val result = WartTestTraverser(OldTime) {
+      import java.text.SimpleDateFormat
+    }
+    assertError(result)(javaError)
+  }
+  test("disable java.text.SimpleDateFormat renamed imports") {
+    val result = WartTestTraverser(OldTime) {
+      import java.text.{ SimpleDateFormat => Something }
+    }
+    assertError(result)(javaError)
+  }
+  test("disable java.text.SimpleDateFormat erased imports") {
+    val result = WartTestTraverser(OldTime) {
+      import java.text.{ SimpleDateFormat => _ }
+    }
+    assertError(result)(javaError)
+  }
+
+  test("disable java.util._ combined imports") {
+    val result = WartTestTraverser(OldTime) {
+      import java.util.{ Date, Calendar, GregorianCalendar, TimeZone }
+    }
+    assertError(result)(javaError)
+  }
+  test("disable java.util._ combined multiline imports") {
+    val result = WartTestTraverser(OldTime) {
+      import java.util.{ Date, Calendar }
+      import java.util.{ GregorianCalendar, TimeZone }
+    }
+    assert(result.errors == List(javaError, javaError))
+  }
+
+  test("disable combined java and joda time imports") {
+    val result = WartTestTraverser(OldTime) {
+      import java.util.{ Date, Calendar }
+      import org.joda.time.Interval
+    }
+    assert(result.errors == List(javaError, jodaError))
+  }
+
+  test("still allow importing java.util._") {
+    val result = WartTestTraverser(OldTime) {
+      import java.util._
+    }
+    assertEmpty(result)
+  }
+  test("still allow importing org.joda._") {
+    val result = WartTestTraverser(OldTime) {
+      import org.joda._
+    }
+    assertEmpty(result)
+  }
+
+  test("disable use of java.util.Date as a val (1)") {
+    val result = WartTestTraverser(OldTime) {
+      import java.util._
+      val x: Date = ???
+    }
+    assertError(result)(javaError)
+  }
+  test("disable use of java.util.Date as a val (2)") {
+    val result = WartTestTraverser(OldTime) {
+      import java.util._
+      val x = new Date()
+    }
+    assert(result.errors == List(javaError, javaError))
+  }
+  test("disable creating instances of java.util.Date (1)") {
+    val result = WartTestTraverser(OldTime) {
+      import java.util._
+      new Date()
+    }
+    assertError(result)(javaError)
+  }
+  test("disable creating instances of java.util.Date (2)") {
+    val result = WartTestTraverser(OldTime) {
+      import java.util._
+      val x: Object = new Date()
+    }
+    assertError(result)(javaError)
+  }
+
+  test("disable aliasing java.util.Date") {
+    val result = WartTestTraverser(OldTime) {
+      type X = java.util.Date
+    }
+    assertError(result)(javaError)
+  }
+  test("disable aliasing org.joda.time.LocalDate") {
+    val result = WartTestTraverser(OldTime) {
+      type X = org.joda.time.LocalDate
+    }
+    assertError(result)(jodaError)
+  }
+
+  test("disable using java.util.Date as a lower type bound") {
+    val result = WartTestTraverser(OldTime) {
+      def x[A >: java.util.Date](a: A): Unit = ()
+    }
+    assertError(result)(javaError)
+  }
+  test("disable using org.joda.time.LocalDate as a lower type bound") {
+    val result = WartTestTraverser(OldTime) {
+      def x[A >: org.joda.time.LocalDate](a: A): Unit = ()
+    }
+    assertError(result)(jodaError)
+  }
+
+  test("disable using java.util.Date as an upper type bound") {
+    val result = WartTestTraverser(OldTime) {
+      def x[A <: java.util.Date](a: A): Unit = ()
+    }
+    assertError(result)(javaError)
+  }
+  test("disable using org.joda.time.LocalDate as an upper type bound") {
+    val result = WartTestTraverser(OldTime) {
+      def x[A <: org.joda.time.LocalDate](a: A): Unit = ()
+    }
+    assertError(result)(jodaError)
+  }
+
+  test("disable using java.util.Date as a function return type") {
+    val result = WartTestTraverser(OldTime) {
+      def x(): java.util.Date = ???
+    }
+    assertError(result)(javaError)
+  }
+  test("disable using org.joda.time.LocalDate as a function return type") {
+    val result = WartTestTraverser(OldTime) {
+      def x(): org.joda.time.LocalDate = ???
+    }
+    assertError(result)(jodaError)
+  }
+
+  test("disable using java.util.Date as a function argument type") {
+    val result = WartTestTraverser(OldTime) {
+      def x(a: java.util.Date): Unit = ()
+    }
+    assertError(result)(javaError)
+  }
+  test("disable using org.joda.time.LocalDate as a function argument type") {
+    val result = WartTestTraverser(OldTime) {
+      def x(a: org.joda.time.LocalDate): Unit = ()
+    }
+    assertError(result)(jodaError)
+  }
+
+  test("disable using java.util.Date as a type parameter (1)") {
+    val result = WartTestTraverser(OldTime) {
+      val x: List[java.util.Date] = List.empty
+    }
+    assertError(result)(javaError)
+  }
+  test("disable using java.util.Date as a type parameter (2)") {
+    val result = WartTestTraverser(OldTime) {
+      val x = List.empty[java.util.Date]
+    }
+    assert(result.errors == List(javaError, javaError))
+  }
+  test("disable using org.joda.time.LocalDate as a type parameter (1)") {
+    val result = WartTestTraverser(OldTime) {
+      val x: List[org.joda.time.LocalDate] = List.empty
+    }
+    assertError(result)(jodaError)
+  }
+  test("disable using org.joda.time.LocalDate as a type parameter (2)") {
+    val result = WartTestTraverser(OldTime) {
+      val x = List.empty[org.joda.time.LocalDate]
+    }
+    assert(result.errors == List(jodaError, jodaError))
+  }
+}


### PR DESCRIPTION
This PR adds a new wart forbidding older date/time libraries in favor of the new Java 8 datetime library, courtesy of @balagez.