### PR TITLE
Add RefinedClasstag wart

### DIFF
--- a/core/src/main/scala/wartremover/contrib/warts/RefinedClasstag.scala
+++ b/core/src/main/scala/wartremover/contrib/warts/RefinedClasstag.scala
@@ -1,0 +1,60 @@
+package org.wartremover.contrib.warts
+
+import org.wartremover.{ WartTraverser, WartUniverse }
+
+object RefinedClasstag extends WartTraverser {
+
+  def ctMessage(typeName: String): String = s"Refined types should not be used in Classtags since only the first type will be checked at runtime. Type found: $typeName"
+  def mfMessage(typeName: String): String = s"Refined types should not be used in Manifests since only the first type will be checked at runtime. Type found: $typeName"
+
+  def apply(u: WartUniverse): u.Traverser = {
+    import u.universe._
+
+    object RefinedTypeTree {
+      def unapply(typ: Tree): Option[Type] = {
+        typ.tpe match {
+          case RefinedType(_) => Some(typ.tpe)
+          case _ => None
+        }
+      }
+    }
+
+    val classTag: TermName = "ClassTag"
+    val applyMethod: TermName = "apply"
+    val scala: TermName = "scala"
+    val reflect: TermName = "reflect"
+    val manifestFactory: TermName = "ManifestFactory"
+    val intersectionType: TermName = "intersectionType"
+
+    new u.Traverser {
+
+      override def traverse(tree: Tree): Unit = {
+
+        tree match {
+          // Ignore trees marked by SuppressWarnings
+          case t if hasWartAnnotation(u)(t) =>
+
+          case TypeApply(Select(Ident(`classTag`), `applyMethod`), args) =>
+            args.foreach {
+              case arg @ RefinedTypeTree(tpe) =>
+                error(u)(arg.pos, ctMessage(tpe.toString))
+              case _ =>
+            }
+            super.traverse(tree)
+
+          case TypeApply(Select(Select(Select(Ident(`scala`), `reflect`), `manifestFactory`), `intersectionType`), args) =>
+            args.foreach {
+              case arg @ RefinedTypeTree(tpe) =>
+                error(u)(arg.pos, mfMessage(tpe.toString))
+              case _ =>
+            }
+            super.traverse(tree)
+
+          case _ =>
+            super.traverse(tree)
+        }
+      }
+    }
+  }
+
+}

--- a/core/src/test/scala/wartremover/contrib/warts/RefinedClasstagTest.scala
+++ b/core/src/test/scala/wartremover/contrib/warts/RefinedClasstagTest.scala
@@ -1,0 +1,76 @@
+package wartremover
+package contrib.warts
+
+import org.scalatest.FunSuite
+import org.wartremover.contrib.test.ResultAssertions
+import org.wartremover.contrib.warts.RefinedClasstag
+import org.wartremover.test.WartTestTraverser
+
+import scala.reflect.ClassTag
+import scala.reflect.runtime.universe._
+
+class RefinedClasstagTest extends FunSuite with ResultAssertions {
+
+  import RefinedClasstagTest._
+
+  def methodWithClassTag[T]()(implicit ct: ClassTag[T]): Unit = {}
+
+  def methodWithManifest[T]()(implicit mf: Manifest[T]): Unit = {}
+
+  test("can't use refined types with classTags") {
+    val result: WartTestTraverser.Result = WartTestTraverser(RefinedClasstag) {
+      methodWithClassTag[A with B]()
+    }
+    assertError(result)(RefinedClasstag.ctMessage(typeOf[A with B].toString))
+  }
+
+  test("can't use refined types with manifests") {
+    val result: WartTestTraverser.Result = WartTestTraverser(RefinedClasstag) {
+      methodWithManifest[A with B]()
+    }
+    assertError(result)(RefinedClasstag.mfMessage(typeOf[A with B].toString))
+  }
+
+  test("can use single trait or an object in classtags") {
+    val result: WartTestTraverser.Result = WartTestTraverser(RefinedClasstag) {
+      methodWithClassTag[A]()
+      methodWithClassTag[B]()
+      methodWithClassTag[C]()
+      methodWithClassTag[Obj.type]()
+    }
+    assertEmpty(result)
+  }
+
+  test("can use single trait or an object in manifests") {
+    val result: WartTestTraverser.Result = WartTestTraverser(RefinedClasstag) {
+      methodWithManifest[A]()
+      methodWithManifest[B]()
+      methodWithManifest[C]()
+      methodWithManifest[Obj.type]()
+    }
+    assertEmpty(result)
+  }
+
+  test("obeys SuppressWarnings") {
+    val result: WartTestTraverser.Result = WartTestTraverser(RefinedClasstag) {
+      @SuppressWarnings(Array("org.wartremover.contrib.warts.RefinedClasstag"))
+      def fun = {
+        methodWithClassTag[A with B]()
+      }
+    }
+    assertEmpty(result)
+  }
+}
+
+object RefinedClasstagTest {
+  trait A
+
+  trait B
+
+  trait C extends A with B
+
+  case object Obj extends A with C
+
+  type Ab = A with B
+
+}


### PR DESCRIPTION
**Description of the problem**

What I call a 'RefinedClasstag' (the name has to be changed, for sure), is a Classtag generated for this kind of methods call: 

    someObject.asInstanceOf[Clazz with Trait]

This code compiles, but is source of mistake. 
Let's take the exemple above again, with following implementations :

    class Clazz {
      def foo = println("foo in Clazz")
    }
    
    trait Trait {
      def bar = println("bar in Trait")
    }

And play with these types and asInstanceOf.

    (new Clazz with Trait).asInstanceOf[Clazz with Trait].foo
   (new Clazz with Trait).asInstanceOf[Clazz with Trait].bar

These lines print "foo in Clazz" and "bar in Trait", as expected.
Now something weird: 

    val clazzWithTrait: Clazz with Trait = (new Clazz).asInstanceOf[Clazz with Trait]
    clazzWithTrait.foo

On could expectd asInstanceOf to throw an exception, since we're try ing to cast a Clazz in to a Clazz with Trait. But instead of an exception, we got the second line printing "foo in Clazz".
And if we try : 

    clazzWithTrait.bar

This time, we got a ClassCastException.
What that means is that if, to be sure, you wrapped your asInstanceOf call into some Try(...), exception would not arise inside this try, but at the first call of an non existing method.
Not so bullet proof, isn't it ?

Despite the fact this is not the expected behavior, this is a "normal" and meaningfull behavior.
The fact is that asInstanceOf is creating a ClassTag to encapsulate the type you want to cast into.
And Classtags (as well as Manifest) does not know about complexe types.
For a Classtag, _Clazz with Trait_ becomes _Clazz_ only.

**What does this wart do ?**
This wart checks your code for Classtags or Manifest created against 'RefinedTypeTree' types, that is ones of the form A with B.

It does not prevent you of using this kind of notation, just of using them in classtags or manifests.

**Why would I do some asInstanceOf, which is already removed by another wart?**
My use was this one: filtering a list of abstract elements depending of their types (like ofType in C#)
I then wrote (simplified version, but the idea is here): 

    implicit class SeqExtension(val s: Seq[_]) extends AnyVal {
      def ofType[T : Classtag]: Seq[T] = s.collect { case t: T => t }
    }

This worked like a charm until I tried to make 

    gameEntities.ofType[Entity with Life with Position]
