### PR TITLE
Rename Warts object to ContribWarts

### DIFF
--- a/sbt-plugin/src/main/scala/wartremover/contrib/ContribWarts.scala
+++ b/sbt-plugin/src/main/scala/wartremover/contrib/ContribWarts.scala
@@ -6,7 +6,7 @@ import wartremover.contrib.ContribWart
 import wartremover.WartRemover
 import wartremover.WartRemover.autoImport.wartremoverClasspaths
 
-object Warts extends AutoPlugin {
+object ContribWarts extends AutoPlugin {
 
   object autoImport {
     val ContribWart = wartremover.contrib.ContribWart


### PR DESCRIPTION
There is a collision between main `wartremover` and `wartremover-contrib` in the `Warts` sbt plugin object.

Consider this scenario:
```scala
// plugins.sbt
addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.2.1")
addSbtPlugin("org.wartremover" % "sbt-wartremover-contrib" % "1.1.0")

// build.sbt
wartremoverWarnings ++= Warts.all // enable all warts from sbt-wartremover (no contrib)
```

This will fail with the following error:
```
error: value all is not a member of object org.wartremover.contrib.Warts                                                                                     
  wartremoverWarnings ++= Warts.all
```

An easy user-side solution for this is to not use this automatically imported `Warts` as is, but fully qualify it:

```scala
wartremoverWarnings ++= wartremover.Warts.all
```

This will work. But implies that if I were already using `sbt-wartremover` and just want to add some warts from this `sbt-wartremover-contrib` I will have to change my previous references to `Warts`, and I don't want to, I just want to add new warts to my warnings list.

So, a transparent solution here is just to rename the `Warts` from `sbt-wartremover-contrib` to `ContribWarts`. In that way, there will be no name clashing between the two different `Warts` objects, and the first example will work as expected.