### PR TITLE
Added the UnintendedLaziness wart

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,23 @@ A name is considered symbolic if the number of characters that aren't letters or
 def :+:(): Unit = {}
 ```
 
+### UnintendedLaziness
+
+The `mapValues` and `filterKeys` methods of maps implicitly turn a strictly evaluated collection into a lazily evaluated one.
+This has been [the subject of many debates](https://issues.scala-lang.org/browse/SI-4776) and will be fixed in the new collections library in Scala 2.13, but until then should be avoided.
+
+You should instead consider using the explicit call to the `view` or `toStream` methods. 
+
+```scala
+val map: Map[Int, Int] = ???
+
+// Won't compile
+val positivesLazyMap = map.filterKeys(_ > 0)
+
+// Won't compile
+val incrementedLazyMap = map.mapValues(_ + 1)
+```
+
 ### UnsafeInheritance
 
 Overriding method implementation can break parent's contract.

--- a/core/src/main/scala/wartremover/contrib/warts/UnintendedLaziness.scala
+++ b/core/src/main/scala/wartremover/contrib/warts/UnintendedLaziness.scala
@@ -1,0 +1,50 @@
+package org.wartremover
+package contrib.warts
+
+object UnintendedLaziness extends WartTraverser {
+  val (errorForFilterKeys: String, errorForMapValues: String) = {
+    def error(name: String) =
+      s"""GenMapLike#$name is disabled because it implicitly creates lazily evaluated collections.
+         |To create lazy collections, use the explicit view or toStream methods""".stripMargin
+
+    (error("filterKeys"), error("mapValues"))
+  }
+
+  def apply(u: WartUniverse): u.Traverser = {
+    import u.universe._
+
+    val maybeGenMapLikeSymbol =
+      try {
+        Option(rootMirror.staticClass("scala.collection.GenMapLike"))
+      } catch {
+        case _: ScalaReflectionException =>
+          // If this happens, the type does not exist, in which case we're using 2.13+, where this wart is a no-op
+          None
+      }
+
+    maybeGenMapLikeSymbol
+      .map { genMapLikeSymbol =>
+        val filterKeys: TermName = "filterKeys"
+        val mapValues: TermName = "mapValues"
+
+        new u.Traverser {
+          override def traverse(tree: Tree): Unit = {
+            tree match {
+              // Ignore trees marked by SuppressWarnings
+              case t if hasWartAnnotation(u)(t) =>
+
+              case t @ Apply(Select(map, `filterKeys`), _) if map.tpe.baseType(genMapLikeSymbol) != NoType =>
+                error(u)(t.pos, errorForFilterKeys)
+
+              case t @ Apply(TypeApply(Select(map, `mapValues`), _), _) if map.tpe.baseType(genMapLikeSymbol) != NoType =>
+                error(u)(t.pos, errorForMapValues)
+
+              case _ =>
+                super.traverse(tree)
+            }
+          }
+        }
+      }
+      .getOrElse(new u.Traverser)
+  }
+}

--- a/core/src/test/scala/wartremover/contrib/warts/UnintendedLazinessTest.scala
+++ b/core/src/test/scala/wartremover/contrib/warts/UnintendedLazinessTest.scala
@@ -1,0 +1,86 @@
+package org.wartremover
+package contrib.test
+
+import org.scalatest.FunSuite
+import org.wartremover.contrib.warts.UnintendedLaziness
+import org.wartremover.test.WartTestTraverser
+
+class UnintendedLazinessTest extends FunSuite with ResultAssertions {
+  private lazy val isScala213: Boolean = try {
+    ClassLoader.getSystemClassLoader.loadClass("scala.collection.GenMapLike")
+    false
+  } catch {
+    case _: ClassNotFoundException => true
+  }
+
+  test("Can't call filterKeys on a map") {
+    val map = Map.empty[String, Int]
+    val result = WartTestTraverser(UnintendedLaziness) {
+      map.filterKeys(_.isEmpty)
+    }
+
+    if (isScala213) {
+      assertEmpty(result)
+    } else {
+      assertError(result)(UnintendedLaziness.errorForFilterKeys)
+    }
+  }
+
+  test("Can't call mapValues on a map") {
+    val map = Map.empty[String, Int]
+    val result = WartTestTraverser(UnintendedLaziness) {
+      map.mapValues(_ + 1)
+    }
+
+    if (isScala213) {
+      assertEmpty(result)
+    } else {
+      assertError(result)(UnintendedLaziness.errorForMapValues)
+    }
+  }
+
+  test("Can call other methods on a map") {
+    val map = Map.empty[String, Int]
+    val result = WartTestTraverser(UnintendedLaziness) {
+      map.filter { case (key, _) => key.isEmpty }
+      map.map { case (key, value) => key -> (value + 1) }
+    }
+    assertEmpty(result)
+  }
+
+  test("Can call filterKeys on anything that's not a map") {
+    val notAMap = new {
+      def filterKeys(p: String => Boolean): Map[String, Int] = ???
+    }
+
+    val result = WartTestTraverser(UnintendedLaziness) {
+      notAMap.filterKeys(_.isEmpty)
+    }
+    assertEmpty(result)
+  }
+
+  test("Can't call mapValues on anything that's not a map") {
+    val notAMap = new {
+      def mapValues[W](f: Int => W): Map[String, W] = ???
+    }
+
+    val result = WartTestTraverser(UnintendedLaziness) {
+      notAMap.mapValues(_ + 1)
+    }
+    assertEmpty(result)
+  }
+
+  test("obeys SuppressWarnings") {
+    val map = Map.empty[String, Int]
+
+    val result = WartTestTraverser(UnintendedLaziness) {
+      @SuppressWarnings(Array("org.wartremover.contrib.warts.UnintendedLaziness"))
+      val _ = {
+        map.filterKeys(_.isEmpty)
+        map.mapValues(_ + 1)
+      }
+    }
+    assertEmpty(result)
+  }
+
+}


### PR DESCRIPTION
The `mapValues` and `filterKeys` methods of maps implicitly turn a strictly evaluated collection into a lazily evaluated one.
This has been [the subject of many debates](https://issues.scala-lang.org/browse/SI-4776) and will be fixed in the new collections library in Scala 2.13, but until then should be avoided.

You should instead consider using the explicit call to the `view` or `toStream` methods.

```scala
val map: Map[Int, Int] = ???

// Won't compile
val positivesLazyMap = map.filterKeys(_ > 0)

// Won't compile
val incrementedLazyMap = map.mapValues(_ + 1)
```