### PR TITLE
Added DiscardedFuture wart

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,3 +205,25 @@ class C extends T {
   override def positive = -1
 }
 ```
+
+### DiscardedFuture
+
+The `andThen` method receives a side-effecting callback, whose return value are discarded.
+This is confusing, because it is different from Function types' `andThen` which compose two instances of functions (e.g. `f andThen g`).
+The `flatMap` method, which can chain the result to other `Future`, may be more appropriate than `andThen`.
+
+```scala
+val f: Future[Int] = fooAsync()
+
+// Won't compile
+f.andThen { 
+  case i if i > 100 => Future.successful(0)
+  case _ => Future.succesful(42)
+}
+
+// Will compile
+f.andThen { 
+  case i if i > 100 => println("side-effect")
+  case _ => println("other side-effect")
+}
+```

--- a/core/src/main/scala/wartremover/contrib/warts/DiscardedFuture.scala
+++ b/core/src/main/scala/wartremover/contrib/warts/DiscardedFuture.scala
@@ -1,0 +1,39 @@
+package org.wartremover
+package contrib.warts
+
+import scala.concurrent.Future
+
+object DiscardedFuture extends WartTraverser {
+
+  val message: String =
+    """andThen discards the return value of callback.
+      |To chain the result of Future to other Future, use flatMap.
+      |""".stripMargin
+
+  def apply(u: WartUniverse): u.Traverser = {
+    import u.universe._
+
+    val andThenMethodName: TermName = TermName("andThen")
+    val futureSymbol = typeOf[Future[Any]]
+    val andThenMethod = futureSymbol.member(andThenMethodName)
+    val futureTypeSymbol = futureSymbol.typeSymbol
+    require(andThenMethod != NoSymbol)
+    require(futureTypeSymbol != NoSymbol)
+
+    new Traverser {
+      override def traverse(tree: Tree): Unit = {
+        tree match {
+          // Ignore trees marked by SuppressWarnings
+          case t if hasWartAnnotation(u)(t) =>
+          case Apply(Apply(method, List(callback)), _) if method.symbol == andThenMethod && callback.tpe
+            .typeArgs(1)
+            .typeSymbol == futureTypeSymbol =>
+            error(u)(tree.pos, message)
+            super.traverse(tree)
+          case _ =>
+            super.traverse(tree)
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/scala/wartremover/contrib/warts/DiscardedFutureTest.scala
+++ b/core/src/test/scala/wartremover/contrib/warts/DiscardedFutureTest.scala
@@ -1,0 +1,58 @@
+package org.wartremover
+package contrib.test
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.wartremover.contrib.warts.DiscardedFuture
+import org.wartremover.test.WartTestTraverser
+
+import scala.concurrent.Future
+import scala.util.Try
+
+class DiscardedFutureTest extends AnyFunSuite with ResultAssertions {
+  implicit val ec: scala.concurrent.ExecutionContext =
+    scala.concurrent.ExecutionContext.global
+
+  test("error if Future is a return type of anonymous partial function`") {
+    val result = WartTestTraverser(DiscardedFuture) {
+      val f = Future.successful(1)
+      f.andThen {
+        case _ => f
+      }
+    }
+    assertError(result)(DiscardedFuture.message)
+  }
+
+  test("error if Future is a return type of the value") {
+    val result = WartTestTraverser(DiscardedFuture) {
+      val f = Future.successful(1)
+      val pf: PartialFunction[Try[Int], Future[String]] = {
+        case _ => Future.successful("")
+      }
+      f.andThen(pf)
+    }
+    assertError(result)(DiscardedFuture.message)
+  }
+
+  test("success if non-Future is a type of return value") {
+    val result = WartTestTraverser(DiscardedFuture) {
+      val f = Future.successful(1)
+      f.andThen {
+        case _ => 1
+      }
+    }
+    assertEmpty(result)
+  }
+
+  test("can suppress warnings") {
+    val result = WartTestTraverser(DiscardedFuture) {
+      @SuppressWarnings(Array("org.wartremover.contrib.warts.DiscardedFuture"))
+      def m() = {
+        val f = Future.successful(1)
+        f.andThen {
+          case _ => f
+        }
+      }
+    }
+    assertEmpty(result)
+  }
+}


### PR DESCRIPTION
The `andThen` method receives a side-effecting callback, whose return value are discarded.
This is confusing, because it is different from Function types' `andThen` which compose two instances of functions (e.g. `f andThen g`).
The `flatMap` method, which can chain the result to other `Future`, may be more appropriate than `andThen`.

```scala
val f: Future[Int] = fooAsync()

// Won't compile: use flatMap instead.
f.andThen { 
  case i if i > 100 => Future.successful(0)
  case _ => Future.succesful(42)
}

// Will compile
f.andThen { 
  case i if i > 100 => println("side-effect")
  case _ => foo.bar() // discarded non-Future return value
}
```

