### PR TITLE
Adding support for import renames in the NoNeedImport wart

### DIFF
--- a/core/src/test/scala/wartremover/contrib/warts/NoNeedImportTest.scala
+++ b/core/src/test/scala/wartremover/contrib/warts/NoNeedImportTest.scala
@@ -18,6 +18,12 @@ class NoNeedImportTest extends AnyFunSuite with ResultAssertions {
     }
     assertError(result)("Import into the wildcard(`something => _`) is meaningless. Remove it.")
   }
+  test("`import scala.util.{ Try, Success => MySuccess, _ }` is disabled") {
+    val result = WartTestTraverser(NoNeedImport) {
+      import scala.util.{  Try, Success => MySuccess, _ }
+    }
+    assertError(result)("The wildcard import exists. Remove other explicitly names of the `import`.")
+  }
   test("`import scala.util.{ Try => _ , _ }` can be used") {
     val result = WartTestTraverser(NoNeedImport) {
       import scala.util.{ Try => _, _ }
@@ -28,6 +34,12 @@ class NoNeedImportTest extends AnyFunSuite with ResultAssertions {
     val result = WartTestTraverser(NoNeedImport) {
       import scala.util._
       import scala.util.{ _ }
+    }
+    assertEmpty(result)
+  }
+  test("`import scala.util.{ Try => MyTry , _ }` can be used") {
+    val result = WartTestTraverser(NoNeedImport) {
+      import scala.util.{ Try => MyTry, _ }
     }
     assertEmpty(result)
   }


### PR DESCRIPTION
Hi,

Currently the `NoNeedImport` wart produces an error in cases where we have something like:
```scala
import scala.util.{ Try => MyTry, _ }
```

This is a false-positive since this import is actually meaningful.

This pull-request fixes this (see tests).

Thanks