### PR TITLE
Add wart CaseClassInheritance

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,3 +227,15 @@ f.andThen {
   case _ => println("other side-effect")
 }
 ```
+
+### CaseClassInheritance
+
+Reports an error when a case class is being inherited. The reason behind this is similar to
+another wartremover rule `FinalCaseClass`, however `CaseClassInheritance` prohibits the code
+that one class inherits another case class, no matter the case class is defined as final or not.
+
+```scala
+case class Car()
+// Won't compile: Case class should not be inherited: Car
+class RedCar() extends Car()
+```

--- a/build.sbt
+++ b/build.sbt
@@ -208,7 +208,7 @@ lazy val sbtPlug: ProjectMatrix = projectMatrix
         .map(_.getName.replaceAll("""\.scala$""", ""))
         .filterNot(deprecatedWarts)
         .sorted
-      val expectCount = 12
+      val expectCount = 13
       assert(
         warts.size == expectCount,
         s"${warts.size} != ${expectCount}. please update build.sbt when add or remove wart"

--- a/core/src/main/scala-2/org/wartremover/contrib/warts/CaseClassInheritance.scala
+++ b/core/src/main/scala-2/org/wartremover/contrib/warts/CaseClassInheritance.scala
@@ -1,0 +1,35 @@
+package org.wartremover
+package contrib.warts
+
+object CaseClassInheritance extends WartTraverser {
+  override def apply(u: WartUniverse): u.Traverser = {
+    new u.Traverser {
+      override def traverse(tree: u.universe.Tree): Unit = {
+        def checkClass(c: u.universe.ClassSymbol): Unit = {
+          val caseBases = c.baseClasses
+            .filter(base => base != c && base.isClass && base.asClass.isCaseClass)
+          if (caseBases.nonEmpty) {
+            error(u)(
+              tree.pos,
+              s"Case class should not be inherited: ${caseBases.map(_.name).mkString(",")}")
+          }
+        }
+
+        import u.universe._
+
+        tree match {
+          case t if hasWartAnnotation(u)(t) =>
+          // Ignore trees marked by SuppressWarnings.
+          case d: ModuleDef =>
+            val m = d.symbol.asModule.moduleClass.asClass
+            checkClass(m)
+          case d: ClassDef =>
+            val c = d.symbol.asClass
+            checkClass(c)
+          case _ =>
+            super.traverse(tree)
+        }
+      }
+    }
+  }
+}

--- a/core/src/main/scala-2/org/wartremover/contrib/warts/CaseClassInheritance.scala
+++ b/core/src/main/scala-2/org/wartremover/contrib/warts/CaseClassInheritance.scala
@@ -6,12 +6,9 @@ object CaseClassInheritance extends WartTraverser {
     new u.Traverser {
       override def traverse(tree: u.universe.Tree): Unit = {
         def checkClass(c: u.universe.ClassSymbol): Unit = {
-          val caseBases = c.baseClasses
-            .filter(base => base != c && base.isClass && base.asClass.isCaseClass)
+          val caseBases = c.baseClasses.filter(base => base != c && base.isClass && base.asClass.isCaseClass)
           if (caseBases.nonEmpty) {
-            error(u)(
-              tree.pos,
-              s"Case class should not be inherited: ${caseBases.map(_.name).mkString(",")}")
+            error(u)(tree.pos, s"Case class should not be inherited: ${caseBases.map(_.name).mkString(",")}")
           }
         }
 

--- a/core/src/main/scala-3/org/wartremover/contrib/warts/CaseClassInheritance.scala
+++ b/core/src/main/scala-3/org/wartremover/contrib/warts/CaseClassInheritance.scala
@@ -1,0 +1,33 @@
+package org.wartremover.contrib.warts
+
+import org.wartremover.WartTraverser
+import org.wartremover.WartUniverse
+
+
+object CaseClassInheritance extends WartTraverser {
+  override def apply(u: WartUniverse): u.Traverser = {
+    new u.Traverser(this) {
+      import q.reflect.*
+      override def traverseTree(tree: Tree)(owner: Symbol): Unit = {
+        def checkClass(c: Symbol): Unit = {
+          val caseBases = c.typeRef.baseClasses
+            .filter(base => base != c && base.isClassDef && base.flags.is(Flags.Case))
+          if (caseBases.nonEmpty) {
+            error(
+              tree.pos,
+              s"Case class should not be inherited: ${caseBases.map(_.name).mkString(",")}")
+          }
+        }
+
+        tree match {
+          case t if hasWartAnnotation(t) =>
+          // Ignore trees marked by SuppressWarnings.
+          case d: ClassDef =>
+            checkClass(d.symbol)
+          case _ =>
+            super.traverseTree(tree)(owner)
+        }
+      }
+    }
+  }
+}

--- a/core/src/main/scala-3/org/wartremover/contrib/warts/CaseClassInheritance.scala
+++ b/core/src/main/scala-3/org/wartremover/contrib/warts/CaseClassInheritance.scala
@@ -3,19 +3,16 @@ package org.wartremover.contrib.warts
 import org.wartremover.WartTraverser
 import org.wartremover.WartUniverse
 
-
 object CaseClassInheritance extends WartTraverser {
   override def apply(u: WartUniverse): u.Traverser = {
     new u.Traverser(this) {
       import q.reflect.*
       override def traverseTree(tree: Tree)(owner: Symbol): Unit = {
         def checkClass(c: Symbol): Unit = {
-          val caseBases = c.typeRef.baseClasses
-            .filter(base => base != c && base.isClassDef && base.flags.is(Flags.Case))
+          val caseBases =
+            c.typeRef.baseClasses.filter(base => base != c && base.isClassDef && base.flags.is(Flags.Case))
           if (caseBases.nonEmpty) {
-            error(
-              tree.pos,
-              s"Case class should not be inherited: ${caseBases.map(_.name).mkString(",")}")
+            error(tree.pos, s"Case class should not be inherited: ${caseBases.map(_.name).mkString(",")}")
           }
         }
 

--- a/core/src/test/scala/org/wartremover/contrib/test/CaseClassInheritanceTest.scala
+++ b/core/src/test/scala/org/wartremover/contrib/test/CaseClassInheritanceTest.scala
@@ -1,0 +1,45 @@
+package org.wartremover
+package contrib.test
+
+import org.wartremover.contrib.warts.CaseClassInheritance
+import org.wartremover.test.WartTestTraverser
+import org.scalatest.funsuite.AnyFunSuite
+
+class CaseClassInheritanceTest extends AnyFunSuite with ResultAssertions {
+  test("case class inheritance disallowed: as class") {
+    val result = WartTestTraverser(CaseClassInheritance) {
+      case class Car()
+      class RedCar() extends Car()
+    }
+    assertError(result)("Case class should not be inherited: Car")
+  }
+
+  test("case class inheritance disallowed: as object") {
+    val result = WartTestTraverser(CaseClassInheritance) {
+      case class Car()
+      object RedCar extends Car()
+    }
+    assertError(result)("Case class should not be inherited: Car")
+  }
+
+  test("regular class inheritance allowed") {
+    val result = WartTestTraverser(CaseClassInheritance) {
+      class Car()
+      class RedCar() extends Car()
+      case class BlueCar() extends Car()
+      object BlackCar extends Car()
+    }
+    assertEmpty(result)
+  }
+
+  test("obeys SuppressWarnings") {
+    val result = WartTestTraverser(CaseClassInheritance) {
+      case class Car()
+      @SuppressWarnings(Array("org.wartremover.contrib.warts.CaseClassInheritance"))
+      class RedCar() extends Car()
+      @SuppressWarnings(Array("org.wartremover.contrib.warts.CaseClassInheritance"))
+      object BlueCar extends Car()
+    }
+    assertEmpty(result)
+  }
+}


### PR DESCRIPTION
This is to add a new wart `CaseClassInheritance`.

The purpose of the wart is similar to the wart `FinalCaseClass` ([doc page](https://www.wartremover.org/doc/warts.html)) in the main repo, however is useful in the case that the non-final case classes are defined in a 3rd Scala library so cannot be modified.

For example, in `mylibrary`, a case class is defined as 

```scala
package library

case class Foo()
```

, and in a piece of local code that uses `mylibrary` as dependency:

```scala
import library.Foo

class Bar() extends Foo() // Should report error.
```

An error could be reported by enabling the new wart. `FinalCaseClass` cannot deal with this case.