### PR TITLE
Minor improvements for the documentation of wart CaseClassInheritance

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,8 +231,8 @@ f.andThen {
 ### CaseClassInheritance
 
 Reports an error when a case class is being inherited. The reason behind this is similar to
-another wartremover rule `FinalCaseClass`, however `CaseClassInheritance` prohibits the code
-that one class inherits another case class, no matter the case class is defined as final or not.
+another wart `FinalCaseClass`, however `CaseClassInheritance` prohibits the code
+where one class inherits another case class, no matter the case class is defined as final or not.
 
 ```scala
 case class Car()


### PR DESCRIPTION
A follow-up on https://github.com/wartremover/wartremover-contrib/pull/648.

In the documentation of `CaseClassInheritance`, the phrase `wartremover rule` is used but is a non-standard saying in wartremover. The patch fixes the minor issue. 